### PR TITLE
Optional plural support

### DIFF
--- a/src/main/java/com/jagrosh/giveawaybot/commands/CreateCommand.java
+++ b/src/main/java/com/jagrosh/giveawaybot/commands/CreateCommand.java
@@ -157,7 +157,7 @@ public class CreateCommand extends Command {
                             }
                             else
                             {
-                                event.replySuccess("Ok! "+num+" winners it is! Finally, what do you want to give away?"+PRIZE);
+                                event.replySuccess("Ok! "+num+" winner(s) it is! Finally, what do you want to give away?"+PRIZE);
                                 waitForPrize(event, tchan, seconds, num);
                             }
                         } catch(NumberFormatException ex) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31016869/42105472-5d19b500-7bc8-11e8-965d-a1a690bc1c07.png)
Changed to 
![image](https://user-images.githubusercontent.com/31016869/42105507-720c3866-7bc8-11e8-9aa9-5cf1a5490c83.png)
Also maintains consistency since this is already done in the `glist` command
![image](https://user-images.githubusercontent.com/31016869/42105531-8559af0c-7bc8-11e8-865a-66544a8f6439.png)
