### PR TITLE
replace discordapp.com with discord.com in message link

### DIFF
--- a/src/main/java/com/jagrosh/giveawaybot/entities/Giveaway.java
+++ b/src/main/java/com/jagrosh/giveawaybot/entities/Giveaway.java
@@ -159,7 +159,7 @@ public class Giveaway
     
     private String messageLink()
     {
-        return String.format("\n<https://discordapp.com/channels/%d/%d/%d>", guildId, channelId, messageId);
+        return String.format("\n<https://discord.com/channels/%d/%d/%d>", guildId, channelId, messageId);
     }
     
     public void end(RestJDA restJDA, Map<Long,Long> additional)


### PR DESCRIPTION
changes the message link in the results of a giveaway. this link works exactly the same away but is shorter, so less obstrusive.